### PR TITLE
Function that accepts swal instance and returns the component

### DIFF
--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -75,7 +75,7 @@ function warningRemoved(props) {
   })
 }
 
-export function withSwal(swalInstance = swal) {
+export function withSwal(swalInstance) {
   swalLibrary = swalInstance
   return SweetAlert
 }

--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -6,6 +6,8 @@ import mousetrap from 'mousetrap'
 import warning from 'warning'
 import outsideTargetHandlerFactory from './utils/outsideTargetHandlerFactory'
 
+let swalLibrary;
+
 const ALLOWS_KEYS = [
   'title',
   'text',
@@ -73,7 +75,7 @@ function warningRemoved(props) {
   })
 }
 
-export default class SweetAlert extends Component {
+export class SweetAlert extends Component {
   /* eslint-disable react/no-unused-prop-types */
   static propTypes = {
     // sweetalert option
@@ -142,7 +144,7 @@ export default class SweetAlert extends Component {
     super(props, context)
 
     this._show = false
-    this.swal = props.swal || swal
+    this.swal = swalLibrary || props.swal || swal
   }
 
   componentDidMount() {
@@ -260,4 +262,9 @@ export default class SweetAlert extends Component {
   render() {
     return null
   }
+}
+
+export default function loadSwal(swalInstance = swal) {
+  swalLibrary = swalInstance;
+  return SweetAlert
 }

--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -263,7 +263,7 @@ class SweetAlert extends Component {
 }
 
 export const asReactComponent = swal => props => (
-  <SweetAlert {...props} swal={swal} />
+  <SweetAlert swal={swal} {...props} />
 )
 
 export default SweetAlert;

--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -6,7 +6,7 @@ import mousetrap from 'mousetrap'
 import warning from 'warning'
 import outsideTargetHandlerFactory from './utils/outsideTargetHandlerFactory'
 
-let swalLibrary;
+let swalLibrary
 
 const ALLOWS_KEYS = [
   'title',
@@ -75,7 +75,12 @@ function warningRemoved(props) {
   })
 }
 
-export class SweetAlert extends Component {
+export function withSwal(swalInstance = swal) {
+  swalLibrary = swalInstance
+  return SweetAlert
+}
+
+export default class SweetAlert extends Component {
   /* eslint-disable react/no-unused-prop-types */
   static propTypes = {
     // sweetalert option
@@ -262,9 +267,4 @@ export class SweetAlert extends Component {
   render() {
     return null
   }
-}
-
-export default function loadSwal(swalInstance = swal) {
-  swalLibrary = swalInstance;
-  return SweetAlert
 }

--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -1,4 +1,4 @@
-import { Component } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import swal from 'sweetalert2'
 import pick from 'lodash.pick'
@@ -75,12 +75,7 @@ function warningRemoved(props) {
   })
 }
 
-export function withSwal(swalInstance) {
-  swalLibrary = swalInstance
-  return SweetAlert
-}
-
-export default class SweetAlert extends Component {
+class SweetAlert extends Component {
   /* eslint-disable react/no-unused-prop-types */
   static propTypes = {
     // sweetalert option
@@ -120,6 +115,7 @@ export default class SweetAlert extends Component {
   /* eslint-enable react/no-unused-prop-types */
 
   static defaultProps = {
+    swal,
     // sweetalert option
     text: null,
     type: null,
@@ -149,7 +145,6 @@ export default class SweetAlert extends Component {
     super(props, context)
 
     this._show = false
-    this.swal = swalLibrary || props.swal || swal
   }
 
   componentDidMount() {
@@ -187,7 +182,7 @@ export default class SweetAlert extends Component {
     warningRemoved(props)
     const { show, onConfirm, onCancel, onClose, onEscapeKey } = props
     if (show) {
-      this.swal(
+      this.props.swal(
         {
           ...pick(props, ALLOWS_KEYS),
           ...OVERWRITE_PROPS,
@@ -257,7 +252,7 @@ export default class SweetAlert extends Component {
 
   handleClose(onClose) {
     if (this._show) {
-      this.swal.close()
+      this.props.swal.close()
       this.unbindEscapeKey()
       if (onClose) onClose()
       this._show = false
@@ -268,3 +263,10 @@ export default class SweetAlert extends Component {
     return null
   }
 }
+
+export const withSwal = swal => props => (
+  <SweetAlert {...props} swal={swal} />
+)
+
+export default SweetAlert;
+

--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import { Component } from 'react'
 import PropTypes from 'prop-types'
 import swal from 'sweetalert2'
 import pick from 'lodash.pick'
@@ -73,198 +73,195 @@ function warningRemoved(props) {
   })
 }
 
-class SweetAlert extends Component {
-  /* eslint-disable react/no-unused-prop-types */
-  static propTypes = {
-    // sweetalert option
-    title: PropTypes.string.isRequired,
-    text: PropTypes.string,
-    swal: PropTypes.func,
-    type: PropTypes.oneOf(['warning', 'error', 'success', 'info', 'input']),
-    customClass: PropTypes.string,
-    showCancelButton: PropTypes.bool,
-    showConfirmButton: PropTypes.bool,
-    confirmButtonText: PropTypes.string,
-    confirmButtonColor: PropTypes.string,
-    confirmButtonClass: PropTypes.string,
-    cancelButtonText: PropTypes.string,
-    cancelButtonClass: PropTypes.string,
-    reverseButtons: PropTypes.bool,
-    buttonsStyling: PropTypes.bool,
-    imageUrl: PropTypes.string,
-    html: PropTypes.bool,
-    animation: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.oneOf(['pop', 'slide-from-top', 'slide-from-bottom']),
-    ]),
-    // inputType: PropTypes.oneOf(ALLOWS_INPUT_TYPES),
-    inputPlaceholder: PropTypes.string,
-    inputValue: PropTypes.string,
-    showLoaderOnConfirm: PropTypes.bool,
+export const asReactComponent = swalInstance => (
+  class SweetAlert extends Component {
+    /* eslint-disable react/no-unused-prop-types */
+    static propTypes = {
+      // sweetalert option
+      title: PropTypes.string.isRequired,
+      text: PropTypes.string,
+      type: PropTypes.oneOf(['warning', 'error', 'success', 'info', 'input']),
+      customClass: PropTypes.string,
+      showCancelButton: PropTypes.bool,
+      showConfirmButton: PropTypes.bool,
+      confirmButtonText: PropTypes.string,
+      confirmButtonColor: PropTypes.string,
+      confirmButtonClass: PropTypes.string,
+      cancelButtonText: PropTypes.string,
+      cancelButtonClass: PropTypes.string,
+      reverseButtons: PropTypes.bool,
+      buttonsStyling: PropTypes.bool,
+      imageUrl: PropTypes.string,
+      html: PropTypes.bool,
+      animation: PropTypes.oneOfType([
+        PropTypes.bool,
+        PropTypes.oneOf(['pop', 'slide-from-top', 'slide-from-bottom']),
+      ]),
+      // inputType: PropTypes.oneOf(ALLOWS_INPUT_TYPES),
+      inputPlaceholder: PropTypes.string,
+      inputValue: PropTypes.string,
+      showLoaderOnConfirm: PropTypes.bool,
 
-    // custom option
-    show: PropTypes.bool,
-    onConfirm: PropTypes.func,
-    onCancel: PropTypes.func,
-    onClose: PropTypes.func,
-    onEscapeKey: PropTypes.func,
-    onOutsideClick: PropTypes.func,
-  }
-  /* eslint-enable react/no-unused-prop-types */
-
-  static defaultProps = {
-    swal,
-    // sweetalert option
-    text: null,
-    type: null,
-    customClass: null,
-    showCancelButton: false,
-    showConfirmButton: true,
-    confirmButtonText: 'OK',
-    confirmButtonColor: '#aedef4',
-    cancelButtonText: 'Cancel',
-    cancelButtonClass: null,
-    confirmButtonClass: null,
-    buttonsStyling: true,
-    reverseButtons: false,
-    imageUrl: null,
-    html: false,
-    animation: true,
-    // inputType: 'text',
-    inputPlaceholder: null,
-    inputValue: null,
-    showLoaderOnConfirm: false,
-
-    // custom option
-    show: false,
-  }
-
-  constructor(props, context) {
-    super(props, context)
-
-    this._show = false
-  }
-
-  componentDidMount() {
-    this.setupWithProps(this.props)
-
-    if (this.props.onOutsideClick) {
-      this.registerOutsideClickHandler(this.props.onOutsideClick)
+      // custom option
+      show: PropTypes.bool,
+      onConfirm: PropTypes.func,
+      onCancel: PropTypes.func,
+      onClose: PropTypes.func,
+      onEscapeKey: PropTypes.func,
+      onOutsideClick: PropTypes.func,
     }
-  }
+    /* eslint-enable react/no-unused-prop-types */
 
-  componentWillReceiveProps(props) {
-    this.setupWithProps(props)
+    static defaultProps = {
+      // sweetalert option
+      text: null,
+      type: null,
+      customClass: null,
+      showCancelButton: false,
+      showConfirmButton: true,
+      confirmButtonText: 'OK',
+      confirmButtonColor: '#aedef4',
+      cancelButtonText: 'Cancel',
+      cancelButtonClass: null,
+      confirmButtonClass: null,
+      buttonsStyling: true,
+      reverseButtons: false,
+      imageUrl: null,
+      html: false,
+      animation: true,
+      // inputType: 'text',
+      inputPlaceholder: null,
+      inputValue: null,
+      showLoaderOnConfirm: false,
 
-    const oldOutsideClickHandler = this.props.onOutsideClick
-    const newOutsideClickHandler = props.onOutsideClick
+      // custom option
+      show: false,
+    }
 
-    if (oldOutsideClickHandler !== newOutsideClickHandler) {
-      if (oldOutsideClickHandler && newOutsideClickHandler) {
-        this.unregisterOutsideClickHandler()
-        this.registerOutsideClickHandler(newOutsideClickHandler)
-      } else if (oldOutsideClickHandler && !newOutsideClickHandler) {
-        this.unregisterOutsideClickHandler()
-      } else if (!oldOutsideClickHandler && newOutsideClickHandler) {
-        this.registerOutsideClickHandler(newOutsideClickHandler)
+    constructor(props, context) {
+      super(props, context)
+
+      this._show = false
+      this._swal = swalInstance
+    }
+
+    componentDidMount() {
+      this.setupWithProps(this.props)
+
+      if (this.props.onOutsideClick) {
+        this.registerOutsideClickHandler(this.props.onOutsideClick)
       }
     }
-  }
 
-  componentWillUnmount() {
-    this.unregisterOutsideClickHandler()
-    this.unbindEscapeKey()
-  }
+    componentWillReceiveProps(props) {
+      this.setupWithProps(props)
 
-  setupWithProps(props) {
-    warningRemoved(props)
-    const { show, onConfirm, onCancel, onClose, onEscapeKey } = props
-    if (show) {
-      this.props.swal(
-        {
-          ...pick(props, ALLOWS_KEYS),
-          ...OVERWRITE_PROPS,
-        }).then(
-          () => {
-            this.handleClickConfirm(onConfirm)
-          },
-          (dismiss) => {
-            this.handleClickCancel(onCancel, dismiss)
-          },
-        )
-      this._show = true
-      if (onEscapeKey) this.bindEscapeKey(onEscapeKey)
-    } else {
-      this.handleClose(onClose)
+      const oldOutsideClickHandler = this.props.onOutsideClick
+      const newOutsideClickHandler = props.onOutsideClick
+
+      if (oldOutsideClickHandler !== newOutsideClickHandler) {
+        if (oldOutsideClickHandler && newOutsideClickHandler) {
+          this.unregisterOutsideClickHandler()
+          this.registerOutsideClickHandler(newOutsideClickHandler)
+        } else if (oldOutsideClickHandler && !newOutsideClickHandler) {
+          this.unregisterOutsideClickHandler()
+        } else if (!oldOutsideClickHandler && newOutsideClickHandler) {
+          this.registerOutsideClickHandler(newOutsideClickHandler)
+        }
+      }
     }
-  }
 
-  registerOutsideClickHandler(handler) {
-    this._outsideClickHandler = outsideTargetHandlerFactory(
-      document.getElementsByClassName('sweet-alert')[0],
-      handler,
-    )
-    this.enableOutsideClick()
-  }
-
-  unregisterOutsideClickHandler() {
-    this.disableOutsideClick()
-    this._outsideClickHandler = null
-  }
-
-  enableOutsideClick() {
-    const fn = this._outsideClickHandler
-    if (fn) {
-      document.addEventListener('mousedown', fn)
-      document.addEventListener('touchstart', fn)
-    }
-  }
-
-  disableOutsideClick() {
-    const fn = this._outsideClickHandler
-    if (fn) {
-      document.removeEventListener('mousedown', fn)
-      document.removeEventListener('touchstart', fn)
-    }
-  }
-
-  bindEscapeKey(onEscapeKey) {
-    mousetrap.bind('esc', onEscapeKey)
-  }
-
-  unbindEscapeKey() {
-    mousetrap.unbind('esc')
-  }
-
-  handleClickConfirm(onConfirm) {
-    if (onConfirm) {
-      onConfirm()
-    }
-  }
-
-  handleClickCancel(onCancel) {
-    if (onCancel) {
-      onCancel()
-    }
-  }
-
-  handleClose(onClose) {
-    if (this._show) {
-      this.props.swal.close()
+    componentWillUnmount() {
+      this.unregisterOutsideClickHandler()
       this.unbindEscapeKey()
-      if (onClose) onClose()
-      this._show = false
+    }
+
+    setupWithProps(props) {
+      warningRemoved(props)
+      const { show, onConfirm, onCancel, onClose, onEscapeKey } = props
+      if (show) {
+        this._swal(
+          {
+            ...pick(props, ALLOWS_KEYS),
+            ...OVERWRITE_PROPS,
+          }).then(
+            () => {
+              this.handleClickConfirm(onConfirm)
+            },
+            (dismiss) => {
+              this.handleClickCancel(onCancel, dismiss)
+            },
+        )
+        this._show = true
+        if (onEscapeKey) this.bindEscapeKey(onEscapeKey)
+      } else {
+        this.handleClose(onClose)
+      }
+    }
+
+    registerOutsideClickHandler(handler) {
+      this._outsideClickHandler = outsideTargetHandlerFactory(
+        document.getElementsByClassName('sweet-alert')[0],
+        handler,
+      )
+      this.enableOutsideClick()
+    }
+
+    unregisterOutsideClickHandler() {
+      this.disableOutsideClick()
+      this._outsideClickHandler = null
+    }
+
+    enableOutsideClick() {
+      const fn = this._outsideClickHandler
+      if (fn) {
+        document.addEventListener('mousedown', fn)
+        document.addEventListener('touchstart', fn)
+      }
+    }
+
+    disableOutsideClick() {
+      const fn = this._outsideClickHandler
+      if (fn) {
+        document.removeEventListener('mousedown', fn)
+        document.removeEventListener('touchstart', fn)
+      }
+    }
+
+    bindEscapeKey(onEscapeKey) {
+      mousetrap.bind('esc', onEscapeKey)
+    }
+
+    unbindEscapeKey() {
+      mousetrap.unbind('esc')
+    }
+
+    handleClickConfirm(onConfirm) {
+      if (onConfirm) {
+        onConfirm()
+      }
+    }
+
+    handleClickCancel(onCancel) {
+      if (onCancel) {
+        onCancel()
+      }
+    }
+
+    handleClose(onClose) {
+      if (this._show) {
+        this._swal.close()
+        this.unbindEscapeKey()
+        if (onClose) onClose()
+        this._show = false
+      }
+    }
+
+    render() {
+      return null
     }
   }
-
-  render() {
-    return null
-  }
-}
-
-export const asReactComponent = swal => props => (
-  <SweetAlert swal={swal} {...props} />
 )
 
-export default SweetAlert;
+export default asReactComponent(swal)
 

--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -264,7 +264,7 @@ class SweetAlert extends Component {
   }
 }
 
-export const withSwal = swal => props => (
+export const asReactComponent = swal => props => (
   <SweetAlert {...props} swal={swal} />
 )
 

--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -6,8 +6,6 @@ import mousetrap from 'mousetrap'
 import warning from 'warning'
 import outsideTargetHandlerFactory from './utils/outsideTargetHandlerFactory'
 
-let swalLibrary
-
 const ALLOWS_KEYS = [
   'title',
   'text',


### PR DESCRIPTION
enables pattern discussed in #5 

can still use just the component like this:
```js
import SweetAlert from 'sweetalert2-react'
```

If we want to render react content inside the modal

```js
import swal from 'sweetalert2'
import { withSwal } from 'sweetalert2-react'
import withReactContent from 'sweetalert2-react-content'
import 'sweetalert2/dist/sweetalert2.css'

export const swalWithReactContent = withReactContent(swal) // normal sweetalert2 API /w React content enabled

export const SwalWithReactContent = withSwal(swalWithReactContent) // React component /w React content enabled
```

@zenflow