### PR TITLE
React children

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,59 @@ render() {
 }
 ```
 
+```js
+import React, { Component } from 'react';
+import { withSwalInstance } from 'sweetalert2-react';
+import swal from 'sweetalert2';
+
+const SweetAlert = withSwalInstance(swal);
+
+// ...
+
+render() {
+  return (
+    <div>
+      <button onClick={() => this.setState({ show: true })}>Alert</button>
+      <SweetAlert
+        show={this.state.show}
+        title="Demo"
+        onConfirm={() => this.setState({ show: false })}
+      >
+        SweetAlert in React
+      </SweetAlert>
+    </div>
+  );
+}
+```
+
+```js
+import React, { Component } from 'react';
+import { withSwalInstance } from 'sweetalert2-react';
+import ReactDOMServer from 'react-dom/server'
+import swal from 'sweetalert2';
+
+const SweetAlert = withSwalInstance(swal);
+
+// ...
+
+render() {
+  return (
+    <div>
+      <button onClick={() => this.setState({ show: true })}>Alert</button>
+      <SweetAlert
+        show={this.state.show}
+        title="Demo"
+        onConfirm={() => this.setState({ show: false })}
+      >
+        {ReactDOMServer.renderToString(
+          <h1>SweetAlert in React</h1>
+        )}
+      </SweetAlert>
+    </div>
+  );
+}
+```
+
 Since 0.6, you can wrap your own sweetalert2 (swal) instance:
 
 ```js

--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import ReactDOMServer from 'react-dom/server'
 import PropTypes from 'prop-types'
 import swal from 'sweetalert2'
 import pick from 'lodash.pick'
@@ -80,6 +81,7 @@ export const withSwalInstance = swalInstance =>
       // sweetalert option
       title: PropTypes.string.isRequired,
       text: PropTypes.string,
+      children: PropTypes.node,
       type: PropTypes.oneOf(['warning', 'error', 'success', 'info', 'input']),
       customClass: PropTypes.string,
       showCancelButton: PropTypes.bool,
@@ -179,10 +181,18 @@ export const withSwalInstance = swalInstance =>
     setupWithProps(props) {
       warningRemoved(props)
       const { show, onConfirm, onCancel, onClose, onEscapeKey } = props
+
       if (show) {
+        let html = props.html
+
+        if (props.children) {
+          html = props.children
+        }
+
         this._swal({
           ...pick(props, ALLOWS_KEYS),
-          ...OVERWRITE_PROPS
+          ...OVERWRITE_PROPS,
+          html,
         }).then(
           () => {
             this.handleClickConfirm(onConfirm)


### PR DESCRIPTION
closes #9 

enables:

```js
<SweetAlert
  show={this.state.show}
  title="Demo"
  onConfirm={() => this.setState({ show: false })}
>
  SweetAlert in React
</SweetAlert>
```

or with react content enabled:
```js
<SwalWithReactContent
  show={this.state.modal2}
> 
  <div>
    <h1>I am title</h1>
    <h2>I am subtitle</h2>
    <p>
      whatever elements you want
    </p>
  </div>
</SwalWithReactContent>
```

the surrounding div is necessary currently and i think it would require changes to sweetalert-react-content to remove. @zenflow