### PR TITLE
Fixed html being a string

### DIFF
--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -92,7 +92,7 @@ export const withSwalInstance = swalInstance =>
       reverseButtons: PropTypes.bool,
       buttonsStyling: PropTypes.bool,
       imageUrl: PropTypes.string,
-      html: PropTypes.bool,
+      html: PropTypes.string,
       animation: PropTypes.oneOfType([
         PropTypes.bool,
         PropTypes.oneOf(['pop', 'slide-from-top', 'slide-from-bottom'])


### PR DESCRIPTION
I got this error:

```js
Warning: Failed prop type: Invalid prop `html` of type `string` supplied to `SweetAlert`, expected `boolean`.
```

So I fixed it in the `propTypes` as it should be.