### PR TITLE
[#28]: Fixes typo in onConfirm(m) preventing firing of event handler

### DIFF
--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -237,7 +237,7 @@ export const withSwalInstance = swalInstance =>
       mousetrap.unbind('esc');
     }
 
-    handleClickConfirm(onConfirmm, result) {
+    handleClickConfirm(onConfirm, result) {
       if (onConfirm) {
         onConfirm(result);
       }


### PR DESCRIPTION
When calling `handleClickConfirm`, the first parameter was being passed in as `onConfirmm`; however, the logic was checking against the variable `onConfirm`. As is evident, this was preventing `onConfirm` from ever being called and was failing to bind to SweetAlerts every time.

This fix modifies one line in that it changes the `onConfirmm` variable to reflect `onConfirm`. Once this change was made, during some local testing, I found that the `onConfirm` callback was back in working order.