### PR TITLE
Run react codemod on lifecycle methods

### DIFF
--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -171,7 +171,7 @@ export const withSwalInstance = swalInstance =>
       }
     }
 
-    componentWillReceiveProps(props) {
+    UNSAFE_componentWillReceiveProps(props) {
       this.setupWithProps(props);
 
       const oldOutsideClickHandler = this.props.onOutsideClick;


### PR DESCRIPTION
Getting deprecation warning. Ran the codemod on the app to rename to unsafe -- backwards-compatible. 

See more https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html

![Screen Shot 2019-10-10 at 5 03 20 PM](https://user-images.githubusercontent.com/5950956/66609977-fd9fe800-eb7f-11e9-98d8-2662382e5b80.png)
